### PR TITLE
Add PHP8 compatibility.

### DIFF
--- a/web/src/components/general/ProgressBlock.js
+++ b/web/src/components/general/ProgressBlock.js
@@ -4,7 +4,7 @@ const messages = [
   'Filling Up Loading Bar',
   'Capitalizing P\'s',
   'Making Up Results',
-  'Updating to PHP7',
+  'Updating to PHP8',
   'Resolving Dependencies',
   'Listening To Jazz',
   'Initiating the Loop',


### PR DESCRIPTION
I noticed that the loading bar does not fully support PHP 8. This fixes that.

Keep up the good work!